### PR TITLE
More domains added

### DIFF
--- a/more-dea.yml
+++ b/more-dea.yml
@@ -393,3 +393,9 @@ fastmail.name
 jasmne.com
 kyrescu.com
 ineedsa.com
+sinagalore.com
+slvlog.com
+suggerin.com
+tinydef.com
+simdpi.com
+servergem.com


### PR DESCRIPTION
sinagalore.com - from https://temp-mail.org/en/
slvlog.com - from https://temp-mail.org/en/
suggerin.com - from https://temp-mail.org/en/
tinydef.com - from https://temp-mail.org/en/
simdpi.com - from https://temp-mail.org/en/
servergem.com - from https://temp-mail.org/en/